### PR TITLE
GLIBC_2.28 not found error -- Fixed!

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -2,13 +2,12 @@ name: Release X-UI Unofficial
 on:
   push:
     tags:
-      - 0.*
+      - "*"
   workflow_dispatch:
 
 jobs:
   release:
-    permissions: write-all
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-18.04
     outputs:
       upload_url: ${{ steps.create_release.outputs.upload_url }}
     steps:
@@ -16,24 +15,23 @@ jobs:
         id: create_release
         uses: actions/create-release@v1
         env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN  }}
         with:
           tag_name: ${{ github.ref }}
           release_name: ${{ github.ref }}
-          draft: true
-          prerelease: true
+          draft: false
+          prerelease: false
   linuxamd64build:
-    permissions: write-all
     name: build x-ui amd64 version
     needs: release
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-18.04
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
       - name: Set up Go
-        uses: actions/setup-go@v2
+        uses: actions/setup-go@v3
         with:
-          go-version: 1.18
-      - name: build linux amd64 version
+          go-version: 1.19
+      - name: Build linux amd64 version
         run: |
           CGO_ENABLED=1 GOOS=linux GOARCH=amd64 go build -o xui-release -v main.go
           mkdir x-ui
@@ -46,38 +44,38 @@ jobs:
           cd bin
           wget https://github.com/XTLS/Xray-core/releases/latest/download/Xray-linux-64.zip
           unzip Xray-linux-64.zip
-          rm -f Xray-linux-64.zip geoip.dat geosite.dat
+          rm -f Xray-linux-64.zip
+          mv xray xray-linux-amd64
+          rm -f geoip.dat geosite.dat
           wget https://github.com/Loyalsoldier/v2ray-rules-dat/releases/latest/download/geoip.dat
           wget https://github.com/Loyalsoldier/v2ray-rules-dat/releases/latest/download/geosite.dat
-          mv xray xray-linux-amd64
           cd ..
           cd ..
       - name: package
         run: tar -zcvf x-ui-linux-amd64.tar.gz x-ui
-      - name: upload
+      - name: Upload to release
         uses: actions/upload-release-asset@v1
         env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN  }}
         with:
           upload_url: ${{ needs.release.outputs.upload_url }}
           asset_path: x-ui-linux-amd64.tar.gz
           asset_name: x-ui-linux-amd64.tar.gz
           asset_content_type: application/gzip
   linuxarm64build:
-    permissions: write-all
     name: build x-ui arm64 version
     needs: release
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-18.04
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
       - name: Set up Go
-        uses: actions/setup-go@v2
+        uses: actions/setup-go@v3
         with:
-          go-version: 1.18
-      - name: build linux arm64 version
+          go-version: 1.19
+      - name: Build linux arm64 version
         run: |
           sudo apt-get update
-          sudo apt install gcc-aarch64-linux-gnu
+          sudo apt install gcc-aarch64-linux-gnu -y
           CGO_ENABLED=1 GOOS=linux GOARCH=arm64 CC=aarch64-linux-gnu-gcc go build -o xui-release -v main.go
           mkdir x-ui
           cp xui-release x-ui/xui-release
@@ -89,35 +87,35 @@ jobs:
           cd bin
           wget https://github.com/XTLS/Xray-core/releases/latest/download/Xray-linux-arm64-v8a.zip
           unzip Xray-linux-arm64-v8a.zip
-          rm -f Xray-linux-arm64-v8a.zip geoip.dat geosite.dat
+          rm -f Xray-linux-arm64-v8a.zip
+          mv xray xray-linux-arm64
+          rm -f geoip.dat geosite.dat
           wget https://github.com/Loyalsoldier/v2ray-rules-dat/releases/latest/download/geoip.dat
           wget https://github.com/Loyalsoldier/v2ray-rules-dat/releases/latest/download/geosite.dat
-          mv xray xray-linux-arm64
           cd ..
           cd ..
       - name: package
         run: tar -zcvf x-ui-linux-arm64.tar.gz x-ui
-      - name: upload
+      - name: Upload to release
         uses: actions/upload-release-asset@v1
         env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN  }}
         with:
           upload_url: ${{ needs.release.outputs.upload_url }}
           asset_path: x-ui-linux-arm64.tar.gz
           asset_name: x-ui-linux-arm64.tar.gz
           asset_content_type: application/gzip
   linuxs390xbuild:
-    permissions: write-all
     name: build x-ui s390x version
     needs: release
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-18.04
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
       - name: Set up Go
-        uses: actions/setup-go@v2
+        uses: actions/setup-go@v3
         with:
-          go-version: 1.18
-      - name: build linux s390x version
+          go-version: 1.19
+      - name: Build linux s390x version
         run: |
           sudo apt-get update
           sudo apt install gcc-s390x-linux-gnu -y
@@ -138,9 +136,9 @@ jobs:
           mv xray xray-linux-s390x
           cd ..
           cd ..
-      - name: package
+      - name: Package
         run: tar -zcvf x-ui-linux-s390x.tar.gz x-ui
-      - name: upload
+      - name: Upload to release
         uses: actions/upload-release-asset@v1
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
Hi @dopaemon , I have seen many X-UI unofficial versions with that well-said **GLIBC_2.28 not found error** when running on older CentOS/Debian (Ubuntu-like) OSs. Mostly on Ubuntu 16.04 LTS. But shockingly, your latest/ customized UI-themed release gave that error on Ubuntu 18.04 LTS also! ( Correct me if I'm wrong. I have been working on multiple X-UI reops) 

The reason for that error is the misconfiguration of /.guthub/workflows/release.yml file. After so many workarounds, a few weeks ago, I found a .yml script to release X-UI which doesn't give this error at all. 

As you helped me to find out the telegram bot's source code, by replying to my [issue](https://github.com/dopaemon/x-ui/issues/51), I decided to help you back by opening up this pr, which you will get rid of GLIBC_2.28 not found error completely and without harm to your source code.

I released a package with the committed release.yml [here](https://github.com/NidukaAkalanka/x-ui.temp/releases/latest). Check the following screenshots also:
# Before
![Before](https://user-images.githubusercontent.com/97357554/201457982-a2ed0382-6e69-48a1-a111-74aecb140e29.PNG)
# After
![Afetr](https://user-images.githubusercontent.com/97357554/201458017-3ba53ab7-1243-481f-b122-f49bc6392451.PNG)

Please do consider Merging this pr if you found it useful.
Thanks and Regards,
Niduka A.
🤍